### PR TITLE
feat: Convert to ESM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ pids
 
 # Coverage directory
 coverage
+junit.xml
 
 # node-waf configuration
 .lock-wscript

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -2,11 +2,9 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "declaration": false,
-    "lib": ["es2017", "dom"],
-    "module": "ES2015",
+    "lib": ["ES2020", "dom"],
     "moduleResolution": "node",
-    "strict": false,
-    "target": "es5"
+    "strict": false
   },
   "files": ["src/main.ts"],
   "include": ["./**/*.ts"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@babel/preset-typescript": "7.13.0",
         "@ctrl/eslint-config": "2.0.6",
         "@jest/globals": "27.0.1",
+        "@sindresorhus/tsconfig": "1.0.2",
         "@types/node": "15.6.1",
         "buffer": "6.0.3",
         "jest": "27.0.1",
@@ -1283,6 +1284,15 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
+    },
+    "node_modules/@sindresorhus/tsconfig": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/tsconfig/-/tsconfig-1.0.2.tgz",
+      "integrity": "sha512-6N3TkxwK6XuRCH/IRQXvp4PwTrRxktE4NpmeFczA283W6rJjcorJKNbjSmgCNVKkofNoawPF9OmCqDVzDv5UPg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -9389,6 +9399,12 @@
           "dev": true
         }
       }
+    },
+    "@sindresorhus/tsconfig": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/tsconfig/-/tsconfig-1.0.2.tgz",
+      "integrity": "sha512-6N3TkxwK6XuRCH/IRQXvp4PwTrRxktE4NpmeFczA283W6rJjcorJKNbjSmgCNVKkofNoawPF9OmCqDVzDv5UPg==",
+      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "buffer": "6.0.3",
         "jest": "27.0.1",
         "jest-junit": "12.1.0",
-        "rollup": "2.50.1",
+        "rollup": "2.50.3",
         "rollup-plugin-livereload": "2.0.0",
         "rollup-plugin-node-builtins": "2.1.2",
         "rollup-plugin-node-globals": "1.4.0",
@@ -28,7 +28,7 @@
         "typescript": "4.3.2"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7283,9 +7283,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.50.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.50.1.tgz",
-      "integrity": "sha512-3MQhSdGpms4xjYrtR3WNHMT+VrWWM4oqUxUC770MmLo1FWFR2pr/OL81HSPC/ifmiu0uMFk0qPGLmjkSMRIESw==",
+      "version": "2.50.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.50.3.tgz",
+      "integrity": "sha512-58KiHnaCzZn6F5yRMjHe7WTZuFj6r4iJVJz5UwvKD6f/xfTy2IdtbR2AVHN6cyfK1tBy//hJ66ebXy6Y1h7HlQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -14037,9 +14037,9 @@
       }
     },
     "rollup": {
-      "version": "2.50.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.50.1.tgz",
-      "integrity": "sha512-3MQhSdGpms4xjYrtR3WNHMT+VrWWM4oqUxUC770MmLo1FWFR2pr/OL81HSPC/ifmiu0uMFk0qPGLmjkSMRIESw==",
+      "version": "2.50.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.50.3.tgz",
+      "integrity": "sha512-58KiHnaCzZn6F5yRMjHe7WTZuFj6r4iJVJz5UwvKD6f/xfTy2IdtbR2AVHN6cyfK1tBy//hJ66ebXy6Y1h7HlQ==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.1"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build:demo": "rollup -c rollup.demo.js",
-    "watch:demo": "rollup -c rollup.demo.js -w",
+    "demo:build": "rollup -c rollup.demo.js",
+    "demo:watch": "rollup -c rollup.demo.js -w",
     "lint": "eslint --ext .js,.ts, .",
     "lint:fix": "eslint --fix --ext .js,.ts, .",
     "prepare": "npm run build",
@@ -42,7 +42,7 @@
     "buffer": "6.0.3",
     "jest": "27.0.1",
     "jest-junit": "12.1.0",
-    "rollup": "2.50.1",
+    "rollup": "2.50.3",
     "rollup-plugin-livereload": "2.0.0",
     "rollup-plugin-node-builtins": "2.1.2",
     "rollup-plugin-node-globals": "1.4.0",
@@ -69,6 +69,6 @@
     "branch": "master"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "crockford",
     "typescript"
   ],
-  "main": "dist/index.js",
-  "module": "dist/module/index.js",
-  "types": "dist/index.d.ts",
+  "type": "module",
+  "exports": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
@@ -26,7 +26,7 @@
     "lint": "eslint --ext .js,.ts, .",
     "lint:fix": "eslint --fix --ext .js,.ts, .",
     "prepare": "npm run build",
-    "build": "tsc -p tsconfig.build.json && tsc -p tsconfig.module.json",
+    "build": "tsc -p tsconfig.build.json",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:ci": "jest --ci --reporters=default --reporters=jest-junit --coverage"
@@ -37,6 +37,7 @@
     "@babel/preset-typescript": "7.13.0",
     "@ctrl/eslint-config": "2.0.6",
     "@jest/globals": "27.0.1",
+    "@sindresorhus/tsconfig": "1.0.2",
     "@types/node": "15.6.1",
     "buffer": "6.0.3",
     "jest": "27.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export function base32Encode(
   let output = '';
 
   for (let i = 0; i < length; i++) {
-    value = (value << 8) | view[i];
+    value = (value << 8) | view[i]!;
     bits += 8;
 
     while (bits >= 5) {
@@ -104,7 +104,7 @@ export function base32Decode(input: string, variant: Variant = 'RFC4648'): Array
   const output = new Uint8Array(((length * 5) / 8) | 0);
 
   for (let i = 0; i < length; i++) {
-    value = (value << 5) | readChar(alphabet, cleanedInput[i]);
+    value = (value << 5) | readChar(alphabet, cleanedInput[i]!);
     bits += 5;
 
     if (bits >= 8) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,6 @@
 {
-  "compileOnSave": false,
+  "extends": "@sindresorhus/tsconfig",
   "compilerOptions": {
-    "moduleResolution": "Node",
-    "lib": ["ES2019"],
-    "target": "ES2018",
-    "module": "CommonJS",
-    "strict": true,
-    "declaration": true,
-    "sourceMap": false,
-    "outDir": "dist"
+    "outDir": "dist",
   }
 }

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "module": "esnext",
-    "declaration": false,
-    "outDir": "dist/module"
-  }
-}


### PR DESCRIPTION
BREAKING CHANGE: Require Node.js 12 (#181) 05320ac
BREAKING CHANGE: This package is now pure ESM. [Please read this.](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c)