### PR TITLE
feat: Use Uint8Array instead of buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,18 @@ npm install @ctrl/ts-base32
 
 ```ts
 import { base32Encode, base32Decode } from '@ctrl/ts-base32';
+import { stringToUint8Array, uint8ArrayToString } from 'uint8array-extras';
 
-console.log(base32Encode(Buffer.from('a')));
+console.log(base32Encode(stringToUint8Array('a')));
 // 'ME======'
 
-console.log(base32Encode(Buffer.from('a'), { padding: false }));
+console.log(base32Encode(stringToUint8Array('a'), { padding: false }));
 // 'ME'
 
 console.log(base32Decode('ME======'));
-// ArrayBuffer { byteLength: 1 }
+// Uint8Array
 
-console.log(Buffer.from(base32Decode('ME======')).toString());
+console.log(uint8ArrayToString(base32Decode('ME======'))
 // 'a'
 ```
 
@@ -32,4 +33,4 @@ console.log(Buffer.from(base32Decode('ME======')).toString());
 
 base32-encode - https://github.com/LinusU/base32-encode  
 base32-decode - https://github.com/LinusU/base32-decode  
-hex-to-array-buffer - https://github.com/LinusU/hex-to-array-buffer
+uint8array-extras - https://github.com/sindresorhus/uint8array-extras

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -1,12 +1,9 @@
-import { Buffer } from 'buffer';
-
 // @ts-expect-error
-import { base32Decode, base32Encode, hexToArrayBuffer } from '../../src/index.js';
+import { base32Decode, base32Encode, hexToUint8Array } from '../../src/index.js';
 
-(window as any).Buffer = Buffer;
 (window as any).base32Decode = base32Decode;
 (window as any).base32Encode = base32Encode;
-(window as any).hexToArrayBuffer = hexToArrayBuffer;
+(window as any).hexToUint8Array = hexToUint8Array;
 
 const input = document.querySelector<HTMLInputElement>('#input')!;
 const output = document.querySelector<HTMLInputElement>('#output')!;
@@ -14,10 +11,21 @@ const output = document.querySelector<HTMLInputElement>('#output')!;
 input.addEventListener('input', event => inputChange((event.target as HTMLInputElement).value));
 output.addEventListener('input', event => outputChange((event.target as HTMLInputElement).value));
 
+const cachedEncoder = new globalThis.TextEncoder();
+const cachedDecoder = new globalThis.TextDecoder();
+
+function stringToUint8Array(str: string) {
+  return cachedEncoder.encode(str);
+}
+
+function uint8ArrayToString(array: Uint8Array) {
+  return cachedDecoder.decode(array);
+}
+
 function inputChange(str: string): void {
-  output.value = base32Encode(Buffer.from(str));
+  output.value = base32Encode(stringToUint8Array(str));
 }
 
 function outputChange(str: string): void {
-  input.value = Buffer.from(base32Decode(str)).toString();
+  input.value = uint8ArrayToString(base32Decode(str));
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/node": "20.11.24",
     "@vitest/coverage-v8": "1.3.1",
     "typescript": "5.3.3",
+    "uint8array-extras": "^1.1.0",
     "vitest": "1.3.1"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@sindresorhus/tsconfig": "5.0.0",
     "@types/node": "20.11.24",
     "@vitest/coverage-v8": "1.3.1",
-    "buffer": "6.0.3",
     "typescript": "5.3.3",
     "vitest": "1.3.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       typescript:
         specifier: 5.3.3
         version: 5.3.3
+      uint8array-extras:
+        specifier: ^1.1.0
+        version: 1.1.0
       vitest:
         specifier: 1.3.1
         version: 1.3.1(@types/node@20.11.24)
@@ -2455,6 +2458,11 @@ packages:
 
   /ufo@1.4.0:
     resolution: {integrity: sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ==}
+    dev: true
+
+  /uint8array-extras@1.1.0:
+    resolution: {integrity: sha512-CVaBSyOmGoFHu+zOVPbetXEXykOd8KHVBHLlqvmaMWpwcq3rewj18xVNbU5uzf48hclnNQhfNaNany2cMHFK/g==}
+    engines: {node: '>=18'}
     dev: true
 
   /undici-types@5.26.5:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: 1.3.1
         version: 1.3.1(vitest@1.3.1)
-      buffer:
-        specifier: 6.0.3
-        version: 6.0.3
       typescript:
         specifier: 5.3.3
         version: 5.3.3
@@ -999,10 +996,6 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
 
-  /base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-    dev: true
-
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
@@ -1037,13 +1030,6 @@ packages:
       electron-to-chromium: 1.4.690
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.23.0)
-    dev: true
-
-  /buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
     dev: true
 
   /cac@6.7.14:
@@ -1584,10 +1570,6 @@ packages:
   /human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
-    dev: true
-
-  /ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
     dev: true
 
   /ignore@5.3.1:

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ const CROCKFORD = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
 type Variant = 'RFC3548' | 'RFC4648' | 'RFC4648-HEX' | 'Crockford';
 
 export function base32Encode(
-  buffer: ArrayBuffer,
+  input: Uint8Array,
   variant: Variant = 'RFC4648',
   options: Partial<{ padding: boolean }> = {},
 ): string {
@@ -32,8 +32,8 @@ export function base32Encode(
   }
 
   const padding = options.padding ?? defaultPadding;
-  const length = buffer.byteLength;
-  const view = new Uint8Array(buffer);
+  const length = input.byteLength;
+  const view = new Uint8Array(input);
 
   let bits = 0;
   let value = 0;
@@ -72,7 +72,7 @@ function readChar(alphabet: string, char: string): number {
   return idx;
 }
 
-export function base32Decode(input: string, variant: Variant = 'RFC4648'): ArrayBuffer {
+export function base32Decode(input: string, variant: Variant = 'RFC4648'): Uint8Array {
   let alphabet: string;
   let cleanedInput: string;
 
@@ -113,13 +113,13 @@ export function base32Decode(input: string, variant: Variant = 'RFC4648'): Array
     }
   }
 
-  return output.buffer;
+  return output;
 }
 
 /**
- * Turn a string of hexadecimal characters into an ArrayBuffer
+ * Turn a string of hexadecimal characters into an Uint8Array
  */
-export function hexToArrayBuffer(hex: string): ArrayBuffer {
+export function hexToUint8Array(hex: string): Uint8Array {
   if (hex.length % 2 !== 0) {
     throw new RangeError('Expected string to be an even number of characters');
   }
@@ -130,5 +130,5 @@ export function hexToArrayBuffer(hex: string): ArrayBuffer {
     view[i / 2] = parseInt(hex.substring(i, i + 2), 16);
   }
 
-  return view.buffer;
+  return view;
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,20 +1,22 @@
+import { Buffer } from 'node:buffer';
+
 import { describe, expect, test } from 'vitest';
 
-import { base32Decode, base32Encode, hexToArrayBuffer } from '../src/index.js';
+import { base32Decode, base32Encode, hexToUint8Array } from '../src/index.js';
 
 import { CROCKFORD_EXTRAS, TEST_CASES } from './test-cases.js';
 
 describe('encode', () => {
   TEST_CASES.forEach(([variant, input, expected]) => {
     test(`should encode ${variant} ${input}`, () => {
-      expect(base32Encode(hexToArrayBuffer(input), variant as any)).toEqual(expected);
+      expect(base32Encode(hexToUint8Array(input), variant as any)).toEqual(expected);
     });
   });
 
   TEST_CASES.forEach(([variant, input, expected]) => {
     test(`should encode w/ padding disabled ${variant} ${input}`, () => {
       const options = { padding: false };
-      expect(base32Encode(hexToArrayBuffer(input), variant as any, options)).toEqual(
+      expect(base32Encode(hexToUint8Array(input), variant as any, options)).toEqual(
         // eslint-disable-next-line no-useless-escape
         expected.replace(/\=/g, ''),
       );
@@ -42,12 +44,12 @@ describe('encode', () => {
 describe('decode', () => {
   TEST_CASES.forEach(([variant, input, expected]) => {
     test(`should decode ${variant} ${input}`, () => {
-      expect(base32Decode(expected, variant as any)).toEqual(hexToArrayBuffer(input));
+      expect(base32Decode(expected, variant as any)).toEqual(hexToUint8Array(input));
     });
   });
   CROCKFORD_EXTRAS.forEach(([variant, input, expected]) => {
     test(`should decode crockford extra ${variant} ${input}`, () => {
-      expect(base32Decode(expected, variant as any)).toEqual(hexToArrayBuffer(input));
+      expect(base32Decode(expected, variant as any)).toEqual(hexToUint8Array(input));
     });
   });
   test('should decode simple examples', () => {
@@ -84,24 +86,24 @@ describe('decode', () => {
 
 describe('hexToArrayBuffer', () => {
   test('should convert characters to ArrayBuffer', () => {
-    expect(hexToArrayBuffer('')).toEqual(Uint8Array.from([]).buffer);
-    expect(hexToArrayBuffer('1337')).toEqual(Uint8Array.from([0x13, 0x37]).buffer);
-    expect(hexToArrayBuffer('aabb')).toEqual(Uint8Array.from([0xaa, 0xbb]).buffer);
-    expect(hexToArrayBuffer('AABB')).toEqual(Uint8Array.from([0xaa, 0xbb]).buffer);
-    expect(hexToArrayBuffer('ceae96a325e1dc5dd4f405d905049ceb')).toEqual(
+    expect(hexToUint8Array('')).toEqual(Uint8Array.from([]));
+    expect(hexToUint8Array('1337')).toEqual(Uint8Array.from([0x13, 0x37]));
+    expect(hexToUint8Array('aabb')).toEqual(Uint8Array.from([0xaa, 0xbb]));
+    expect(hexToUint8Array('AABB')).toEqual(Uint8Array.from([0xaa, 0xbb]));
+    expect(hexToUint8Array('ceae96a325e1dc5dd4f405d905049ceb')).toEqual(
       Uint8Array.from([
         0xce, 0xae, 0x96, 0xa3, 0x25, 0xe1, 0xdc, 0x5d, 0xd4, 0xf4, 0x05, 0xd9, 0x05, 0x04, 0x9c,
         0xeb,
-      ]).buffer,
+      ]),
     );
-    expect(hexToArrayBuffer('CEAE96A325E1DC5DD4F405D905049CEB')).toEqual(
+    expect(hexToUint8Array('CEAE96A325E1DC5DD4F405D905049CEB')).toEqual(
       Uint8Array.from([
         0xce, 0xae, 0x96, 0xa3, 0x25, 0xe1, 0xdc, 0x5d, 0xd4, 0xf4, 0x05, 0xd9, 0x05, 0x04, 0x9c,
         0xeb,
-      ]).buffer,
+      ]),
     );
   });
   test('should error on uneven length', () => {
-    expect(() => hexToArrayBuffer('123')).toThrow();
+    expect(() => hexToUint8Array('123')).toThrow();
   });
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'node:buffer';
 
+import { stringToUint8Array } from 'uint8array-extras';
 import { describe, expect, test } from 'vitest';
 
 import { base32Decode, base32Encode, hexToUint8Array } from '../src/index.js';
@@ -25,6 +26,7 @@ describe('encode', () => {
 
   test('should encode simple examples', () => {
     expect(base32Encode(Buffer.from('a'))).toBe('ME======');
+    expect(base32Encode(stringToUint8Array('a'))).toBe('ME======');
     expect(base32Encode(Buffer.from('be'))).toBe('MJSQ====');
     expect(base32Encode(Buffer.from('bee'))).toBe('MJSWK===');
     expect(base32Encode(Buffer.from('beer'))).toBe('MJSWK4Q=');


### PR DESCRIPTION
BREAKING CHANGE: switches from buffer to UInt8Array see https://sindresorhus.com/blog/goodbye-nodejs-buffer